### PR TITLE
Add sshpass

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ENV ANSIBLE_VERSION=9.5.1
 
 RUN apk update && \
   apk upgrade && \
-  apk add gnupg git rsync openssh-client python3 python3-dev py3-pip py3-psycopg2 build-base openssl-dev libffi-dev cargo && \
+  apk add gnupg git rsync openssh-client python3 python3-dev py3-pip py3-psycopg2 build-base openssl-dev libffi-dev cargo sshpass && \
   apk add --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community sops && \
   pip3 install --break-system-packages -U ansible==${ANSIBLE_VERSION} requests netaddr boto3 kubernetes PyMySQL && \
   apk del build-base openssl-dev libffi-dev cargo && \


### PR DESCRIPTION
The addition of further dependencies is always somewhat undesirable, due to the increase in image size, higher maintenance costs, etc. However, I personally think that `sshpass` is important and useful in conjunction with Ansible. When using a password with SSH, the following error message is thrown by Ansible in a container with this image:

```bash
fatal: [30101]: FAILED! => {"msg": "to use the 'ssh' connection type with passwords or pkcs11_provider, you must install the sshpass program"}
```

This PR adds `sshpass` to the Docker image to avoid having to add dependencies within a container during a normal Ansible use case.
